### PR TITLE
cooler correction

### DIFF
--- a/Languages/English/Keyed/RWHS_Keys.xml
+++ b/Languages/English/Keyed/RWHS_Keys.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <LanguageData>
 	<!-- Heat Pushing -->
 
@@ -57,10 +57,15 @@
 	<StatsReport_RWHS_Unit_TargetTemperature>{0} C</StatsReport_RWHS_Unit_TargetTemperature>
 
 	<StatsReport_RWHS_SidesTempGradient>Temperature difference between both sides</StatsReport_RWHS_SidesTempGradient>
-	<StatsReport_RWHS_Equation_SidesTempGradient>cold - hot</StatsReport_RWHS_Equation_SidesTempGradient>
+	<StatsReport_RWHS_Equation_SidesTempGradient>hot - cold</StatsReport_RWHS_Equation_SidesTempGradient>
 	<StatsReport_RWHS_Calculus_SidesTempGradient>{0} - {1}</StatsReport_RWHS_Calculus_SidesTempGradient>
 	<StatsReport_RWHS_Unit_SidesTempGradient>{0} C</StatsReport_RWHS_Unit_SidesTempGradient>
 
+	<StatsReport_RWHS_TempOverLimit>Degrees over 40C</StatsReport_RWHS_TempOverLimit>
+	<StatsReport_RWHS_Equation_TempOverLimit>hot - 40</StatsReport_RWHS_Equation_TempOverLimit>
+	<StatsReport_RWHS_Calculus_TempOverLimit>{0} - 40</StatsReport_RWHS_Calculus_TempOverLimit>
+	<StatsReport_RWHS_Unit_TempOverLimit>{0} C</StatsReport_RWHS_Unit_TempOverLimit>
+	
 	<StatsReport_RWHS_TargetTempDiff>Difference between target and actual temperature</StatsReport_RWHS_TargetTempDiff>
 	<StatsReport_RWHS_Equation_TargetTempDiff>targetTemp - roomTemp</StatsReport_RWHS_Equation_TargetTempDiff>
 	<StatsReport_RWHS_Calculus_TargetTempDiff>{0} - {1}</StatsReport_RWHS_Calculus_TargetTempDiff>
@@ -80,8 +85,8 @@
 	<StatsReport_RWHS_Unit_EfficiencyLossPerDegree>{0} C^-1</StatsReport_RWHS_Unit_EfficiencyLossPerDegree>
 
 	<StatsReport_RWHS_RelativeEfficiency>Efficiency</StatsReport_RWHS_RelativeEfficiency>
-	<StatsReport_RWHS_Equation_RelativeEfficiency>1 - sidesTempDiff * efficiencyLossPerDegree</StatsReport_RWHS_Equation_RelativeEfficiency>
-	<StatsReport_RWHS_Calculus_RelativeEfficiency>1 - {0} * {1}</StatsReport_RWHS_Calculus_RelativeEfficiency>
+	<StatsReport_RWHS_Equation_RelativeEfficiency>1 - max(sidesTempDiff, tempOverLimit) * efficiency</StatsReport_RWHS_Equation_RelativeEfficiency>
+	<StatsReport_RWHS_Calculus_RelativeEfficiency>1 - max({0}, {1}) * {2}</StatsReport_RWHS_Calculus_RelativeEfficiency>
 	<StatsReport_RWHS_Unit_RelativeEfficiency>{0} %</StatsReport_RWHS_Unit_RelativeEfficiency>
 
 	<StatsReport_RWHS_LerpEfficiency>Efficiency</StatsReport_RWHS_LerpEfficiency>

--- a/Languages/English/Keyed/RWHS_Keys.xml
+++ b/Languages/English/Keyed/RWHS_Keys.xml
@@ -56,16 +56,11 @@
 	<StatsReport_RWHS_TargetTemperature>Target temperature</StatsReport_RWHS_TargetTemperature>
 	<StatsReport_RWHS_Unit_TargetTemperature>{0} C</StatsReport_RWHS_Unit_TargetTemperature>
 
-	<StatsReport_RWHS_SidesTempGradient>Temperature difference between both sides</StatsReport_RWHS_SidesTempGradient>
-	<StatsReport_RWHS_Equation_SidesTempGradient>hot - cold</StatsReport_RWHS_Equation_SidesTempGradient>
-	<StatsReport_RWHS_Calculus_SidesTempGradient>{0} - {1}</StatsReport_RWHS_Calculus_SidesTempGradient>
+	<StatsReport_RWHS_SidesTempGradient>Temperature difference between both sides or over 40C</StatsReport_RWHS_SidesTempGradient>
+	<StatsReport_RWHS_Equation_SidesTempGradient>hot - min(cold,40)</StatsReport_RWHS_Equation_SidesTempGradient>
+	<StatsReport_RWHS_Calculus_SidesTempGradient>{0} - min({1},40)</StatsReport_RWHS_Calculus_SidesTempGradient>
 	<StatsReport_RWHS_Unit_SidesTempGradient>{0} C</StatsReport_RWHS_Unit_SidesTempGradient>
 
-	<StatsReport_RWHS_TempOverLimit>Degrees over 40C</StatsReport_RWHS_TempOverLimit>
-	<StatsReport_RWHS_Equation_TempOverLimit>hot - 40</StatsReport_RWHS_Equation_TempOverLimit>
-	<StatsReport_RWHS_Calculus_TempOverLimit>{0} - 40</StatsReport_RWHS_Calculus_TempOverLimit>
-	<StatsReport_RWHS_Unit_TempOverLimit>{0} C</StatsReport_RWHS_Unit_TempOverLimit>
-	
 	<StatsReport_RWHS_TargetTempDiff>Difference between target and actual temperature</StatsReport_RWHS_TargetTempDiff>
 	<StatsReport_RWHS_Equation_TargetTempDiff>targetTemp - roomTemp</StatsReport_RWHS_Equation_TargetTempDiff>
 	<StatsReport_RWHS_Calculus_TargetTempDiff>{0} - {1}</StatsReport_RWHS_Calculus_TargetTempDiff>
@@ -85,8 +80,8 @@
 	<StatsReport_RWHS_Unit_EfficiencyLossPerDegree>{0} C^-1</StatsReport_RWHS_Unit_EfficiencyLossPerDegree>
 
 	<StatsReport_RWHS_RelativeEfficiency>Efficiency</StatsReport_RWHS_RelativeEfficiency>
-	<StatsReport_RWHS_Equation_RelativeEfficiency>1 - max(sidesTempDiff, tempOverLimit) * efficiency</StatsReport_RWHS_Equation_RelativeEfficiency>
-	<StatsReport_RWHS_Calculus_RelativeEfficiency>1 - max({0}, {1}) * {2}</StatsReport_RWHS_Calculus_RelativeEfficiency>
+	<StatsReport_RWHS_Equation_RelativeEfficiency>1 - sidesTempDiff * efficiencyLossPerDegree</StatsReport_RWHS_Equation_RelativeEfficiency>
+	<StatsReport_RWHS_Calculus_RelativeEfficiency>1 - {0} * {1}</StatsReport_RWHS_Calculus_RelativeEfficiency>
 	<StatsReport_RWHS_Unit_RelativeEfficiency>{0} %</StatsReport_RWHS_Unit_RelativeEfficiency>
 
 	<StatsReport_RWHS_LerpEfficiency>Efficiency</StatsReport_RWHS_LerpEfficiency>

--- a/Source/RWHS_TempControl_RoomExchange.cs
+++ b/Source/RWHS_TempControl_RoomExchange.cs
@@ -1,4 +1,4 @@
-using RimWorld;
+﻿using RimWorld;
 using UnityEngine;
 using Verse;
 
@@ -23,11 +23,7 @@ namespace RWHS
             float cooledRoomTemp = intVec3_1.GetTemperature(tempController.Map);
             float extRoomTemp = intVec3_2.GetTemperature(tempController.Map);
             float efficiencyLossPerDegree = 1.0f / 130.0f; // SOS2 internal value, means loss of efficiency for each degree above targettemp, lose 50% at 65C above targetTemp, 100% at 130+
-            float sidesTempGradient = (extRoomTemp - cooledRoomTemp);
-            if (extRoomTemp - 40f > sidesTempGradient)
-            {
-                sidesTempGradient = extRoomTemp - 40f;
-            }
+            float sidesTempGradient = extRoomTemp - (cooledRoomTemp < 40 ? cooledRoomTemp : 40);
             float efficiency = (1f - sidesTempGradient * efficiencyLossPerDegree);
             return efficiency;
         }

--- a/Source/RWHS_TempControl_RoomExchange.cs
+++ b/Source/RWHS_TempControl_RoomExchange.cs
@@ -1,4 +1,4 @@
-﻿using RimWorld;
+using RimWorld;
 using UnityEngine;
 using Verse;
 
@@ -23,7 +23,11 @@ namespace RWHS
             float cooledRoomTemp = intVec3_1.GetTemperature(tempController.Map);
             float extRoomTemp = intVec3_2.GetTemperature(tempController.Map);
             float efficiencyLossPerDegree = 1.0f / 130.0f; // SOS2 internal value, means loss of efficiency for each degree above targettemp, lose 50% at 65C above targetTemp, 100% at 130+
-            float sidesTempGradient = (cooledRoomTemp - extRoomTemp);
+            float sidesTempGradient = (extRoomTemp - cooledRoomTemp);
+            if (extRoomTemp - 40f > sidesTempGradient)
+            {
+                sidesTempGradient = extRoomTemp - 40f;
+            }
             float efficiency = (1f - sidesTempGradient * efficiencyLossPerDegree);
             return efficiency;
         }

--- a/Source/StatWorker_TempControl_RoomExchange_MaxACPerSecond.cs
+++ b/Source/StatWorker_TempControl_RoomExchange_MaxACPerSecond.cs
@@ -63,10 +63,11 @@ namespace RWHS
             float energyPerSecond = tempControl.Props.energyPerSecond; // the power of the radiator
             float roomSurface = intVec3_1.GetRoomGroup(tempController.Map).CellCount;
             float coolingConversionRate = 4.16666651f; // Celsius cooled per Joules*Second*Meter^2  conversion rate
-            float sidesTempGradient = (cooledRoomTemp - extRoomTemp);
-            float efficiency = (1f - sidesTempGradient * efficiencyLossPerDegree);
-            float maxACPerSecond = energyPerSecond * efficiency / roomSurface * coolingConversionRate; // max cooling power possible
-
+            float sidesTempGradient = (extRoomTemp - cooledRoomTemp);
+            float tempOverLimit = extRoomTemp - 40;
+            float tempHigher = sidesTempGradient > tempOverLimit ? sidesTempGradient : tempOverLimit;
+            float efficiency = (1f - tempHigher * efficiencyLossPerDegree); // a negative value indicates heat generation
+            float maxACPerSecond = energyPerSecond * efficiency / roomSurface * coolingConversionRate; // max cooling power possible, positive value indicates heat generation
             SEB seb = new SEB("StatsReport_RWHS");
             seb.Simple("CooledRoomTemp", cooledRoomTemp);
             seb.Simple("ExteriorRoomTemp", extRoomTemp);
@@ -74,8 +75,9 @@ namespace RWHS
             seb.Simple("EnergyPerSecond", energyPerSecond);
             seb.Simple("CooledRoomSurface", roomSurface);
             seb.Simple("ACConversionRate", coolingConversionRate);
-            seb.Full("SidesTempGradient", sidesTempGradient, cooledRoomTemp, extRoomTemp);
-            seb.Full("RelativeEfficiency", efficiency * 100, sidesTempGradient, efficiencyLossPerDegree);
+            seb.Full("SidesTempGradient", sidesTempGradient, extRoomTemp, cooledRoomTemp);
+            seb.Full("TempOverLimit", tempOverLimit, extRoomTemp);
+            seb.Full("RelativeEfficiency", efficiency * 100, sidesTempGradient, tempOverLimit, efficiencyLossPerDegree);
             seb.Full("MaxACPerSecond", maxACPerSecond, energyPerSecond, efficiency, roomSurface, coolingConversionRate);
 
             return seb.ToString();

--- a/Source/StatWorker_TempControl_RoomExchange_MaxACPerSecond.cs
+++ b/Source/StatWorker_TempControl_RoomExchange_MaxACPerSecond.cs
@@ -63,11 +63,10 @@ namespace RWHS
             float energyPerSecond = tempControl.Props.energyPerSecond; // the power of the radiator
             float roomSurface = intVec3_1.GetRoomGroup(tempController.Map).CellCount;
             float coolingConversionRate = 4.16666651f; // Celsius cooled per Joules*Second*Meter^2  conversion rate
-            float sidesTempGradient = (extRoomTemp - cooledRoomTemp);
-            float tempOverLimit = extRoomTemp - 40;
-            float tempHigher = sidesTempGradient > tempOverLimit ? sidesTempGradient : tempOverLimit;
-            float efficiency = (1f - tempHigher * efficiencyLossPerDegree); // a negative value indicates heat generation
+            float sidesTempGradient = extRoomTemp - (cooledRoomTemp < 40 ? cooledRoomTemp : 40);
+            float efficiency = (1f - sidesTempGradient * efficiencyLossPerDegree); // a negative value indicates heat generation
             float maxACPerSecond = energyPerSecond * efficiency / roomSurface * coolingConversionRate; // max cooling power possible, positive value indicates heat generation
+
             SEB seb = new SEB("StatsReport_RWHS");
             seb.Simple("CooledRoomTemp", cooledRoomTemp);
             seb.Simple("ExteriorRoomTemp", extRoomTemp);
@@ -76,8 +75,7 @@ namespace RWHS
             seb.Simple("CooledRoomSurface", roomSurface);
             seb.Simple("ACConversionRate", coolingConversionRate);
             seb.Full("SidesTempGradient", sidesTempGradient, extRoomTemp, cooledRoomTemp);
-            seb.Full("TempOverLimit", tempOverLimit, extRoomTemp);
-            seb.Full("RelativeEfficiency", efficiency * 100, sidesTempGradient, tempOverLimit, efficiencyLossPerDegree);
+            seb.Full("RelativeEfficiency", efficiency * 100, sidesTempGradient, efficiencyLossPerDegree);
             seb.Full("MaxACPerSecond", maxACPerSecond, energyPerSecond, efficiency, roomSurface, coolingConversionRate);
 
             return seb.ToString();


### PR DESCRIPTION
the calculation for temperature difference was changed from (cold - hot) to (hot - cold) to match Rimworld source.  Added condition check for over 40C.  Coolers loss efficiency if the hot side is hotter than the cold side or if the hot side is over 40C.  They reach 0% efficiency when 130 degrees over either of these limits